### PR TITLE
Added printer drivers for CUPS - Gutenprint

### DIFF
--- a/cups/Dockerfile.template
+++ b/cups/Dockerfile.template
@@ -9,6 +9,7 @@ RUN install_packages \
     libnss-mdns \
     foomatic-db-compressed-ppds \
     printer-driver-brlaser \
+    printer-driver-gutenprint \
     hplip
 
 # Add script

--- a/cups/Dockerfile.template
+++ b/cups/Dockerfile.template
@@ -7,10 +7,7 @@ RUN install_packages \
     avahi-daemon \
     dbus \
     libnss-mdns \
-    foomatic-db-compressed-ppds \
-    printer-driver-brlaser \
-    printer-driver-gutenprint \
-    hplip
+    printer-driver-gutenprint
 
 # Add script
 COPY run.sh /


### PR DESCRIPTION
Printer drivers for CUPS
This package includes a CUPS driver based on Gutenprint.
The CUPS drivers contain all of the files needed to support photo-quality printing on any printer supported by Gutenprint.
Gutenprint is the print facility for the GIMP, and in addition a suite of drivers that may be used with common UNIX spooling systems using GhostScript or CUPS. These drivers provide printing quality for UNIX/Linux on a par with proprietary vendor-supplied drivers in many cases, and can be used for many of the most demanding printing tasks. Gutenprint was formerly known as Gimp-Print.